### PR TITLE
refactor: 2nd page PDF content defaults to no_answ if no selection

### DIFF
--- a/PDFGenerator.php
+++ b/PDFGenerator.php
@@ -434,6 +434,12 @@ class PDFGenerator extends \ExternalModules\AbstractExternalModule {
 
             $this->console_log("Processing key: $key");
             $this->console_log("The user chose: " . $user_choice);
+
+            if (empty($user_choice) || $user_choice == 'no_answr') {
+                // default to no_answr if no user choice is made, for now
+                $user_choice = 'no_answ';
+            }
+
             $this->console_log("The user will see: " . $value[$user_choice]);
             $this->console_log("The content is: ");
             $this->console_log(json_encode($resourcesData[$value[$user_choice]]));

--- a/resources/lookup.json
+++ b/resources/lookup.json
@@ -67,6 +67,7 @@
         "6": "mindfulness_class"
     },
     "phq_action": {
+        "no_answ": "hmhi_crisis_line_safeut",
         "1": "mental_health_provider",
         "2": "eap",
         "3": "pcp",
@@ -75,6 +76,7 @@
         "6": "mindfulness_class"
     },
     "sleep_action": {
+        "no_answ": "sleep_essential",
         "1": "insomnia_class",
         "2": "sleep_own_plan",
         "3": "health_coaching",


### PR DESCRIPTION
adds no_answ to lookup for some sections

will need to handle tobacco, alcohol, drug that don't have no_answ option